### PR TITLE
feat(models): add Llama Stack integration with policy router and remote fallbacks

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,12 @@
+# Local LlamaStack (required)
+LLAMA_LOCAL_BASE_URL=http://localhost:8080
+LLAMA_LOCAL_MODEL=llama-3.2-3b-instruct
+LLAMA_LOCAL_CHAT_PATH=/v1/chat/completions
+LLAMA_LOCAL_EMBED_PATH=/v1/embeddings
+
+# Auth and timeout
+LLAMA_API_KEY=change-me
+LLM_TIMEOUT_S=30
+
+# Router override for emergencies
+ECOLE_FORCE_PROVIDER=local

--- a/README.md
+++ b/README.md
@@ -1,1 +1,31 @@
 # eCole
+
+## Using Llama Stack
+
+This project uses [Llama Stack](https://github.com/meta-llama/llama-stack) for all LLM features.
+Currently only a fast local model is available, but the router is prepared for future
+remote endpoints.
+
+### Configuration
+
+Copy `.env.example` to `.env` and adjust values as needed.
+
+| Variable | Description |
+| --- | --- |
+| `LLAMA_LOCAL_BASE_URL` | URL of your local Llama Stack instance |
+| `LLAMA_API_KEY` | Shared API key (if needed) |
+| `ECOLE_FORCE_PROVIDER` | Force router to `local` (remote values reserved for future use) |
+
+After editing `.env`, run the app:
+
+```bash
+uvicorn ecole.backend.app:app --reload
+```
+
+All traffic currently stays on the Llama 3.2‑3B model. Support for remote models
+such as Llama 4 Scout or Llama 3.3‑70B will be added in a future release.
+
+### Security
+
+Llama Stack should not be exposed directly to the internet. Place it behind a
+reverse proxy that enforces authentication.

--- a/ecole/backend/cortex/executive.py
+++ b/ecole/backend/cortex/executive.py
@@ -1,5 +1,5 @@
 from ..state.schema import AgentState
-from ..models.llm import LocalLLM
+from ..models.llm import llm
 from ..brain import frontal, temporal, limbic, basal_ganglia, parietal, cerebellum
 from ..memory import store
 from .action_registry import ACTION_REGISTRY
@@ -10,7 +10,7 @@ PRIORITY_ORDER = {"comfort": 0, "clarify": 1, "plan": 2, "routine": 3}
 class ExecutiveController:
     def __init__(self, registry=None):
         self.registry = registry or ACTION_REGISTRY
-        self.llm = LocalLLM()
+        self.llm = llm
         self.modules = [frontal, temporal, limbic, basal_ganglia, parietal, cerebellum]
 
     def decide(self, state: AgentState) -> list:
@@ -31,4 +31,15 @@ class ExecutiveController:
             return action.get("content", "")
         if name == "write_memory":
             return "memory stored"
-        return self.llm.generate(action.get("content", ""))
+        messages = [
+            {"role": "system", "content": "You are eCole, warm and supportive."},
+            {"role": "user", "content": action.get("content", "")},
+        ]
+        expected_context = sum(len(m["content"]) for m in messages)
+        expected_output = action.get("max_tokens", 800)
+        task = {
+            "type": action.get("type", "general_chat"),
+            "expected_context_tokens": expected_context,
+            "expected_output_tokens": expected_output,
+        }
+        return self.llm.generate(task, messages, max_tokens=expected_output)

--- a/ecole/backend/models/llm.py
+++ b/ecole/backend/models/llm.py
@@ -1,5 +1,92 @@
-class LocalLLM:
-    """Stub for local LLM client."""
+"""Unified LLM facade with routing and fallbacks."""
+from __future__ import annotations
 
-    def generate(self, prompt: str) -> str:
-        return f"LLM response: {prompt}"
+import logging
+import os
+from typing import Dict, List, Optional
+
+from .llm_provider import LlamaStackClient, NullEchoClient, LLMError
+from .model_router import pick_model
+
+logger = logging.getLogger(__name__)
+
+
+class LLM:
+    def __init__(self, *, transport_overrides: Dict[str, object] | None = None):
+        api_key = os.getenv("LLAMA_API_KEY")
+        timeout_s = int(os.getenv("LLM_TIMEOUT_S", "30"))
+        transport_overrides = transport_overrides or {}
+
+        def build(prefix: str) -> Optional[LlamaStackClient]:
+            base = os.getenv(f"{prefix}_BASE_URL") or os.getenv(f"{prefix}_URL")
+            if not base:
+                return None
+            chat_path = os.getenv(f"{prefix}_CHAT_PATH", "/v1/chat/completions")
+            embed_path = os.getenv(f"{prefix}_EMBED_PATH", "/v1/embeddings")
+            return LlamaStackClient(
+                base,
+                api_key,
+                timeout_s,
+                chat_path=chat_path,
+                embed_path=embed_path,
+                transport=transport_overrides.get(prefix),
+            )
+
+        self.clients: Dict[str, LlamaStackClient] = {
+            "local": build("LLAMA_LOCAL") or NullEchoClient(),
+        }
+        scout = build("LLAMA_REMOTE_SCOUT")
+        if scout:
+            self.clients["remote-scout"] = scout
+        seventy = build("LLAMA_REMOTE_70B")
+        if seventy:
+            self.clients["remote-70b"] = seventy
+
+        self.models = {
+            "local": os.getenv("LLAMA_LOCAL_MODEL", "llama-3.2-3b-instruct"),
+            "remote-scout": os.getenv("LLAMA_REMOTE_SCOUT_MODEL", "llama-4-scout"),
+            "remote-70b": os.getenv("LLAMA_REMOTE_70B_MODEL", "llama-3.3-70b-instruct"),
+        }
+
+    # ------------------------------------------------------------------
+    def _client_for(self, provider: str) -> LlamaStackClient:
+        client = self.clients.get(provider)
+        if not client:
+            raise LLMError(f"provider {provider} unavailable")
+        return client
+
+    # ------------------------------------------------------------------
+    def generate(self, task: Dict, messages: List[Dict], **kwargs) -> str:
+        choice = pick_model(task)
+        provider = choice["provider"]
+        model = choice["model"]
+        params = {**choice.get("params", {}), **kwargs}
+        client = self.clients.get(provider)
+        if client is None:
+            logger.info("provider %s unavailable, falling back to local", provider)
+            client = self._client_for("local")
+            model = self.models["local"]
+        try:
+            resp = client.chat(messages, model=model, **params)
+        except LLMError:
+            if provider != "local":
+                logger.warning("remote provider failed, falling back to local")
+                client = self._client_for("local")
+                model = self.models["local"]
+                resp = client.chat(messages, model=model, **params)
+            else:
+                raise
+        content = resp.get("content", "")
+        max_tokens = params.get("max_tokens")
+        if max_tokens:
+            content = content[:max_tokens]
+        return content
+
+    # ------------------------------------------------------------------
+    def embed(self, texts: List[str], task_hint: str | None = None, model: str | None = None) -> List[List[float]]:
+        client = self._client_for("local")
+        model = model or self.models["local"]
+        return client.embed(texts, model=model)
+
+
+llm = LLM()

--- a/ecole/backend/models/llm_provider.py
+++ b/ecole/backend/models/llm_provider.py
@@ -1,0 +1,124 @@
+import json
+import logging
+from typing import List, Dict, Optional
+
+import httpx
+from pydantic import BaseModel, ValidationError
+from tenacity import Retrying, stop_after_attempt, wait_exponential_jitter
+
+
+logger = logging.getLogger(__name__)
+
+
+class LLMError(Exception):
+    """Raised when the LLM provider fails."""
+
+    def __init__(self, message: str, status: int | None = None):
+        super().__init__(message)
+        self.status = status
+
+
+class LLMProvider:
+    """Abstract interface for LLM interactions."""
+
+    def chat(self, messages: List[Dict], model: Optional[str] = None, **kwargs) -> Dict:
+        raise NotImplementedError
+
+    def embed(self, texts: List[str], model: Optional[str] = None, **kwargs) -> List[List[float]]:
+        raise NotImplementedError
+
+
+class _ChatChoice(BaseModel):
+    message: Dict[str, str]
+
+
+class _ChatResponse(BaseModel):
+    choices: List[_ChatChoice]
+
+
+class _EmbeddingData(BaseModel):
+    embedding: List[float]
+
+
+class _EmbeddingResponse(BaseModel):
+    data: List[_EmbeddingData]
+
+
+class LlamaStackClient(LLMProvider):
+    """Client for Llama Stack or OpenAI compatible APIs."""
+
+    def __init__(
+        self,
+        base_url: str,
+        api_key: str | None = None,
+        timeout_s: int = 30,
+        chat_path: str = "/v1/chat/completions",
+        embed_path: str = "/v1/embeddings",
+        transport: httpx.BaseTransport | None = None,
+    ):
+        self.base_url = base_url.rstrip("/")
+        self.api_key = api_key
+        self.timeout_s = timeout_s
+        self.chat_path = chat_path
+        self.embed_path = embed_path
+        self._client = httpx.Client(transport=transport)
+
+    # ------------------------------------------------------------------
+    def _make_headers(self) -> Dict[str, str]:
+        headers = {"Content-Type": "application/json"}
+        if self.api_key:
+            headers["Authorization"] = f"Bearer {self.api_key}"
+        return headers
+
+    def _request(self, path: str, payload: Dict) -> httpx.Response:
+        for attempt in Retrying(
+            stop=stop_after_attempt(3),
+            wait=wait_exponential_jitter(initial=1, max=8),
+            reraise=True,
+        ):
+            with attempt:
+                resp = self._client.post(
+                    f"{self.base_url}{path}",
+                    json=payload,
+                    headers=self._make_headers(),
+                    timeout=self.timeout_s,
+                )
+                resp.raise_for_status()
+                return resp
+
+    # ------------------------------------------------------------------
+    def chat(self, messages: List[Dict], model: Optional[str] = None, **kwargs) -> Dict:
+        payload = {"model": model, "messages": messages}
+        payload.update(kwargs)
+        try:
+            resp = self._request(self.chat_path, payload)
+            data = resp.json()
+            parsed = _ChatResponse(**data)
+            content = parsed.choices[0].message.get("content", "")
+            return {"content": content, "raw": data}
+        except (httpx.HTTPError, ValidationError, KeyError, IndexError) as e:
+            logger.warning("chat request failed: %s", e)
+            raise LLMError(str(e))
+
+    def embed(self, texts: List[str], model: Optional[str] = None, **kwargs) -> List[List[float]]:
+        payload = {"model": model, "input": texts}
+        payload.update(kwargs)
+        try:
+            resp = self._request(self.embed_path, payload)
+            data = resp.json()
+            parsed = _EmbeddingResponse(**data)
+            return [d.embedding for d in parsed.data]
+        except (httpx.HTTPError, ValidationError, KeyError, IndexError) as e:
+            logger.warning("embedding request failed: %s", e)
+            raise LLMError(str(e))
+
+
+class NullEchoClient(LLMProvider):
+    """Simple echo client for development and tests."""
+
+    def chat(self, messages: List[Dict], model: Optional[str] = None, **kwargs) -> Dict:
+        last = messages[-1]["content"] if messages else ""
+        return {"content": f"echo: {last}"}
+
+    def embed(self, texts: List[str], model: Optional[str] = None, **kwargs) -> List[List[float]]:
+        return [[float(len(t))] for t in texts]

--- a/ecole/backend/models/model_router.py
+++ b/ecole/backend/models/model_router.py
@@ -1,0 +1,45 @@
+"""Policy based model router."""
+import os
+from typing import Dict
+
+
+LOCAL_MODEL = os.getenv("LLAMA_LOCAL_MODEL", "llama-3.2-3b-instruct")
+SCOUT_MODEL = os.getenv("LLAMA_REMOTE_SCOUT_MODEL", "llama-4-scout")
+MODEL_70B = os.getenv("LLAMA_REMOTE_70B_MODEL", "llama-3.3-70b-instruct")
+
+SCOUT_AVAILABLE = os.getenv("LLAMA_REMOTE_SCOUT_BASE_URL") or os.getenv("LLAMA_REMOTE_SCOUT_URL")
+MODEL_70B_AVAILABLE = os.getenv("LLAMA_REMOTE_70B_BASE_URL") or os.getenv("LLAMA_REMOTE_70B_URL")
+
+MODEL_MAP = {
+    "local": LOCAL_MODEL,
+    "remote-scout": SCOUT_MODEL,
+    "remote-70b": MODEL_70B,
+}
+
+
+def pick_model(task: Dict) -> Dict:
+    """Pick a model based on task metadata."""
+    force = os.getenv("ECOLE_FORCE_PROVIDER")
+    if force in MODEL_MAP:
+        provider = force
+    else:
+        if (
+            SCOUT_AVAILABLE
+            and (
+                task.get("type") == "lifelog_long_context"
+                or task.get("expected_context_tokens", 0) > 100_000
+            )
+        ):
+            provider = "remote-scout"
+        elif (
+            MODEL_70B_AVAILABLE
+            and (
+                task.get("type") in {"complex_reasoning", "long_plan"}
+                or task.get("expected_output_tokens", 0) > 2_000
+            )
+        ):
+            provider = "remote-70b"
+        else:
+            provider = "local"
+    model = MODEL_MAP.get(provider, LOCAL_MODEL)
+    return {"provider": provider, "model": model, "params": {}}

--- a/ecole/backend/models/tests/test_llm_integration.py
+++ b/ecole/backend/models/tests/test_llm_integration.py
@@ -1,0 +1,46 @@
+import json
+import sys
+import os
+
+import httpx
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../../")))
+
+from ecole.backend.models.llm import LLM
+
+
+def test_generate_fallback_and_trim(monkeypatch):
+    # setup env
+    monkeypatch.setenv("LLAMA_LOCAL_BASE_URL", "https://local")
+    monkeypatch.setenv("LLAMA_LOCAL_MODEL", "local")
+    monkeypatch.setenv("LLAMA_REMOTE_70B_URL", "https://remote")
+    monkeypatch.setenv("LLAMA_REMOTE_70B_MODEL", "r70b")
+
+    def remote_handler(request: httpx.Request):
+        return httpx.Response(500, json={"error": "boom"})
+
+    captured = {}
+
+    def local_handler(request: httpx.Request):
+        captured["json"] = json.loads(request.content.decode())
+        return httpx.Response(200, json={"choices": [{"message": {"content": "abcdefghij"}}]})
+
+    transports = {
+        "LLAMA_REMOTE_70B": httpx.MockTransport(remote_handler),
+        "LLAMA_LOCAL": httpx.MockTransport(local_handler),
+    }
+    model = LLM(transport_overrides=transports)
+
+    messages = [
+        {"role": "system", "content": "sys"},
+        {"role": "user", "content": "hello"},
+    ]
+    task = {
+        "type": "complex_reasoning",
+        "expected_context_tokens": 10,
+        "expected_output_tokens": 10,
+    }
+
+    reply = model.generate(task, messages, max_tokens=5)
+    assert reply == "abcde"
+    assert captured["json"]["messages"] == messages

--- a/ecole/backend/models/tests/test_llm_provider.py
+++ b/ecole/backend/models/tests/test_llm_provider.py
@@ -1,0 +1,46 @@
+import httpx
+import pytest
+import sys
+import os
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../../")))
+
+from ecole.backend.models.llm_provider import LlamaStackClient, LLMError
+
+
+def make_client(handler):
+    transport = httpx.MockTransport(handler)
+    return LlamaStackClient("https://example.com", api_key=None, timeout_s=1, transport=transport)
+
+
+def test_chat_success():
+    def handler(request):
+        return httpx.Response(200, json={"choices": [{"message": {"content": "hi"}}]})
+
+    client = make_client(handler)
+    resp = client.chat([{"role": "user", "content": "hi"}], model="m")
+    assert resp["content"] == "hi"
+
+
+def test_chat_retry(monkeypatch):
+    attempts = {"n": 0}
+
+    def handler(request):
+        attempts["n"] += 1
+        if attempts["n"] < 3:
+            raise httpx.ReadTimeout("timeout")
+        return httpx.Response(200, json={"choices": [{"message": {"content": "ok"}}]})
+
+    client = make_client(handler)
+    resp = client.chat([{"role": "user", "content": "hi"}], model="m")
+    assert resp["content"] == "ok"
+    assert attempts["n"] == 3
+
+
+def test_chat_http_error():
+    def handler(request):
+        return httpx.Response(500, json={"error": "boom"})
+
+    client = make_client(handler)
+    with pytest.raises(LLMError):
+        client.chat([{"role": "user", "content": "hi"}], model="m")

--- a/ecole/backend/models/tests/test_router.py
+++ b/ecole/backend/models/tests/test_router.py
@@ -1,0 +1,57 @@
+import os
+import sys
+import importlib
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../../")))
+
+import ecole.backend.models.model_router as model_router
+
+
+def get_router(monkeypatch):
+    monkeypatch.setenv("LLAMA_LOCAL_MODEL", "local")
+    monkeypatch.setenv("LLAMA_REMOTE_SCOUT_MODEL", "scout")
+    monkeypatch.setenv("LLAMA_REMOTE_70B_MODEL", "70b")
+    monkeypatch.setenv("LLAMA_REMOTE_SCOUT_URL", "https://scout")
+    monkeypatch.setenv("LLAMA_REMOTE_70B_URL", "https://70b")
+    importlib.reload(model_router)
+    return model_router
+
+
+def test_default_local(monkeypatch):
+    mr = get_router(monkeypatch)
+    monkeypatch.delenv("ECOLE_FORCE_PROVIDER", raising=False)
+    res = mr.pick_model({"type": "general", "expected_context_tokens": 10, "expected_output_tokens": 10})
+    assert res["provider"] == "local"
+    assert res["model"] == "local"
+
+
+def test_scout_by_context(monkeypatch):
+    mr = get_router(monkeypatch)
+    res = mr.pick_model({"type": "general", "expected_context_tokens": 150_000, "expected_output_tokens": 10})
+    assert res["provider"] == "remote-scout"
+    assert res["model"] == "scout"
+
+
+def test_scout_by_type(monkeypatch):
+    mr = get_router(monkeypatch)
+    res = mr.pick_model({"type": "lifelog_long_context", "expected_context_tokens": 10, "expected_output_tokens": 10})
+    assert res["provider"] == "remote-scout"
+
+
+def test_70b_by_reasoning(monkeypatch):
+    mr = get_router(monkeypatch)
+    res = mr.pick_model({"type": "complex_reasoning", "expected_context_tokens": 10, "expected_output_tokens": 10})
+    assert res["provider"] == "remote-70b"
+
+
+def test_70b_by_output(monkeypatch):
+    mr = get_router(monkeypatch)
+    res = mr.pick_model({"type": "general", "expected_context_tokens": 10, "expected_output_tokens": 5000})
+    assert res["provider"] == "remote-70b"
+
+
+def test_force_override(monkeypatch):
+    mr = get_router(monkeypatch)
+    monkeypatch.setenv("ECOLE_FORCE_PROVIDER", "remote-70b")
+    res = mr.pick_model({"type": "general", "expected_context_tokens": 10, "expected_output_tokens": 10})
+    assert res["provider"] == "remote-70b"

--- a/ecole/requirements.txt
+++ b/ecole/requirements.txt
@@ -3,3 +3,5 @@ uvicorn
 pydantic
 chromadb
 pyyaml
+httpx
+tenacity

--- a/scripts/smoke_chat.py
+++ b/scripts/smoke_chat.py
@@ -1,0 +1,27 @@
+"""Send a quick chat to verify routing."""
+import argparse
+import json
+
+from ecole.backend.models.llm import llm
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("message", help="User message")
+    parser.add_argument(
+        "--task",
+        default='{"type":"general","expected_context_tokens":100,"expected_output_tokens":200}',
+        help="Task JSON",
+    )
+    args = parser.parse_args()
+    task = json.loads(args.task)
+    messages = [
+        {"role": "system", "content": "You are eCole."},
+        {"role": "user", "content": args.message},
+    ]
+    reply = llm.generate(task, messages)
+    print(reply)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add LLMProvider abstraction with Llama Stack client and echo client
- implement policy-based router for local vs remote models
- refactor LLM facade and executive to support routing and fallbacks
- document Llama Stack setup and add smoke test script
- hide remote model configuration until endpoints become available

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6897307091608326b41b08eefb3c7135